### PR TITLE
allow possibility to build yarn modules and add centos8 image

### DIFF
--- a/8.0/Dockerfile.centos8
+++ b/8.0/Dockerfile.centos8
@@ -44,8 +44,8 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm && \
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
 
-# Install Apache httpd, PHP and yarn
-RUN yum -y module enable php:remi-$PHP_VERSION && \
+# Install Apache httpd, PHP, nodejs v14 and yarn
+RUN yum -y module enable php:remi-$PHP_VERSION nodejs:14 && \
     INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
@@ -53,7 +53,7 @@ RUN yum -y module enable php:remi-$PHP_VERSION && \
                   php-ldap php-pecl-igbinary php-pecl-imagick-im6 \
                   php-pecl-redis5 php-phpiredis php-pecl-zip yarn" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    yum install -y tzdata && \
+    yum install -y tzdata nodejs && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
 

--- a/8.0/Dockerfile.centos8
+++ b/8.0/Dockerfile.centos8
@@ -1,0 +1,122 @@
+FROM centos/s2i-core-centos8
+
+# This image provides an Apache+PHP environment for running PHP
+# applications.
+
+EXPOSE 8080
+EXPOSE 8443
+
+# Description
+# This image provides an Apache 2.4 + PHP 8.0 environment for running PHP applications.
+# Exposed ports:
+# * 8080 - alternative port for http
+
+ENV PHP_VERSION=8.0 \
+    PHP_VER_SHORT=80 \
+    NAME=php
+
+ENV SUMMARY="Platform for building and running PHP $PHP_VERSION applications" \
+    DESCRIPTION="PHP $PHP_VERSION available as container is a base platform for \
+building and running various PHP $PHP_VERSION applications and frameworks. \
+PHP is an HTML-embedded scripting language. PHP attempts to make it easy for developers \
+to write dynamically generated web pages. PHP also offers built-in database integration \
+for several commercial and non-commercial database management systems, so writing \
+a database-enabled webpage with PHP is fairly simple. The most common use of PHP coding \
+is probably as a replacement for CGI scripts."
+
+LABEL summary="${SUMMARY}" \
+      description="${DESCRIPTION}" \
+      io.k8s.description="${DESCRIPTION}" \
+      io.k8s.display-name="Apache 2.4 with PHP ${PHP_VERSION}" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,${NAME},${NAME}${PHP_VER_SHORT},${NAME}-${PHP_VER_SHORT}" \
+      io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
+      io.s2i.scripts-url="image:///usr/libexec/s2i" \
+      name="ubi8/${NAME}-${PHP_VER_SHORT}" \
+      com.redhat.component="${NAME}-${PHP_VER_SHORT}-container" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \
+      usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi8/${NAME}-${PHP_VER_SHORT} sample-server" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# Enable EPEL, Remi and Yarn Repository on CentOS/RHEL
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm && \
+    curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
+
+# Install Apache httpd and PHP
+RUN yum -y module enable php:remi-$PHP_VERSION && \
+    INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
+                  php-gd php-intl php-ldap php-mbstring php-pdo \
+                  php-process php-soap php-opcache php-xml \
+                  php-gmp php-pecl-apcu mod_ssl hostname \
+                  php-ldap php-pecl-igbinary php-pecl-imagick-im6 \
+                  php-pecl-redis5 php-phpiredis php-pecl-zip yarn" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum install -y tzdata && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+ENV PHP_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/php/ \
+    APP_DATA=${APP_ROOT}/src \
+    PHP_DEFAULT_INCLUDE_PATH=/usr/share/pear \
+    PHP_SYSCONF_PATH=/etc \
+    PHP_HTTPD_CONF_FILE=php.conf \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/conf.d \
+    HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+    HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_MODULES_CONF_D_PATH=/etc/httpd/conf.modules.d \
+    HTTPD_VAR_RUN=/var/run/httpd \
+    HTTPD_DATA_PATH=/var/www \
+    HTTPD_DATA_ORIG_PATH=/var/www \
+    HTTPD_VAR_PATH=/var
+
+RUN php -v
+
+# Install PHP extensions
+RUN INSTALL_PREREQUIS="gcc-c++ gcc php-devel php-pear yum-utils" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PREREQUIS --nogpgcheck && \
+    rpm -V $INSTALL_PREREQUIS && \
+    yum -y clean all --enablerepo='*'
+
+# CA for cURL
+RUN echo curl.cainfo="/etc/ssl/certs/ca-bundle.crt" >> `php --ini | grep "Scan for additional .ini files" | sed -e "s|.*:\s*||"`/20-curl.ini
+
+# MONGODB
+RUN pecl install mongodb && \
+    echo extension=mongodb.so >> `php --ini | grep "Scan for additional .ini files" | sed -e "s|.*:\s*||"`/30-mongodb.ini
+
+# MSSQL
+RUN curl https://packages.microsoft.com/config/rhel/8/prod.repo > /etc/yum.repos.d/mssql-release.repo && \
+    yum -y remove unixODBC-utf16 unixODBC-utf16-devel && \
+    dnf install --allowerasing -y https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/libcom_err-1.45.6-1.el8.x86_64.rpm \
+                                  https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/e2fsprogs-libs-1.45.6-1.el8.x86_64.rpm \
+                                  https://rpmfind.net/linux/centos/8.3.2011/BaseOS/x86_64/os/Packages/e2fsprogs-1.45.6-1.el8.x86_64.rpm && \
+    ACCEPT_EULA=Y yum  -y install msodbcsql17 && \
+    ACCEPT_EULA=Y yum -y install mssql-tools && \
+    yum -y install unixODBC-devel && \
+    rpm -V msodbcsql17 mssql-tools unixODBC-devel
+
+RUN pecl install sqlsrv && \
+    echo extension=sqlsrv.so >> `php --ini | grep "Scan for additional .ini files" | sed -e "s|.*:\s*||"`/20-sqlsrv.ini
+RUN pecl install pdo_sqlsrv && \
+    echo extension=pdo_sqlsrv.so >> `php --ini | grep "Scan for additional .ini files" | sed -e "s|.*:\s*||"`/30-pdo_sqlsrv.ini
+
+# Display PHP extensions in log
+RUN php -v
+RUN php -m
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# Reset permissions of filesystem to default values
+RUN chmod +x -Rv /usr/libexec/ && /usr/libexec/container-setup && rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/8.0/Dockerfile.centos8
+++ b/8.0/Dockerfile.centos8
@@ -44,7 +44,7 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm && \
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
 
-# Install Apache httpd and PHP
+# Install Apache httpd, PHP and yarn
 RUN yum -y module enable php:remi-$PHP_VERSION && \
     INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
@@ -89,9 +89,7 @@ RUN pecl install mongodb && \
 # MSSQL
 RUN curl https://packages.microsoft.com/config/rhel/8/prod.repo > /etc/yum.repos.d/mssql-release.repo && \
     yum -y remove unixODBC-utf16 unixODBC-utf16-devel && \
-    dnf install --allowerasing -y https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/libcom_err-1.45.6-1.el8.x86_64.rpm \
-                                  https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/e2fsprogs-libs-1.45.6-1.el8.x86_64.rpm \
-                                  https://rpmfind.net/linux/centos/8.3.2011/BaseOS/x86_64/os/Packages/e2fsprogs-1.45.6-1.el8.x86_64.rpm && \
+    yum -y install libcom_err e2fsprogs-libs e2fsprogs && \
     ACCEPT_EULA=Y yum  -y install msodbcsql17 && \
     ACCEPT_EULA=Y yum -y install mssql-tools && \
     yum -y install unixODBC-devel && \

--- a/8.0/Dockerfile.centos8
+++ b/8.0/Dockerfile.centos8
@@ -32,12 +32,11 @@ LABEL summary="${SUMMARY}" \
       io.openshift.tags="builder,${NAME},${NAME}${PHP_VER_SHORT},${NAME}-${PHP_VER_SHORT}" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
-      name="ubi8/${NAME}-${PHP_VER_SHORT}" \
+      name="centos8/${NAME}-${PHP_VER_SHORT}" \
       com.redhat.component="${NAME}-${PHP_VER_SHORT}-container" \
       version="1" \
-      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       help="For more information visit https://github.com/sclorg/s2i-${NAME}-container" \
-      usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi8/${NAME}-${PHP_VER_SHORT} sample-server" \
+      usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app centos8/${NAME}-${PHP_VER_SHORT} sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 # Enable EPEL, Remi and Yarn Repository on CentOS/RHEL

--- a/8.0/Dockerfile.centos8
+++ b/8.0/Dockerfile.centos8
@@ -1,4 +1,4 @@
-FROM centos/s2i-core-centos8
+FROM centos/s2i-core-centos8:1
 
 # This image provides an Apache+PHP environment for running PHP
 # applications.
@@ -13,6 +13,7 @@ EXPOSE 8443
 
 ENV PHP_VERSION=8.0 \
     PHP_VER_SHORT=80 \
+    NODEJS_VERSION=14 \
     NAME=php
 
 ENV SUMMARY="Platform for building and running PHP $PHP_VERSION applications" \
@@ -27,7 +28,7 @@ is probably as a replacement for CGI scripts."
 LABEL summary="${SUMMARY}" \
       description="${DESCRIPTION}" \
       io.k8s.description="${DESCRIPTION}" \
-      io.k8s.display-name="Apache 2.4 with PHP ${PHP_VERSION}" \
+      io.k8s.display-name="Apache 2.4 with PHP ${PHP_VERSION} NODEJS ${NODEJS_VERSION}" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,${NAME},${NAME}${PHP_VER_SHORT},${NAME}-${PHP_VER_SHORT}" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
@@ -44,8 +45,8 @@ RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm && \
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
 
-# Install Apache httpd, PHP, nodejs v14 and yarn
-RUN yum -y module enable php:remi-$PHP_VERSION nodejs:14 && \
+# Install Apache httpd, PHP, nodejs and yarn
+RUN yum -y module enable php:remi-$PHP_VERSION nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="php php-mysqlnd php-pgsql php-bcmath \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \

--- a/8.0/Dockerfile.rhel8
+++ b/8.0/Dockerfile.rhel8
@@ -40,9 +40,10 @@ LABEL summary="${SUMMARY}" \
       usage="s2i build https://github.com/sclorg/s2i-php-container.git --context-dir=${PHP_VERSION}/test/test-app ubi8/${NAME}-${PHP_VER_SHORT} sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-# Enable EPEL and Remi Repository on CentOS/RHEL
+# Enable EPEL, Remi and Yarn Repository on CentOS/RHEL
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm
+    dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm && \
+    curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
 
 # Install Apache httpd and PHP
 RUN yum -y module enable php:remi-$PHP_VERSION && \
@@ -50,7 +51,7 @@ RUN yum -y module enable php:remi-$PHP_VERSION && \
                   php-gd php-intl php-ldap php-mbstring php-pdo \
                   php-process php-soap php-opcache php-xml \
                   php-gmp php-pecl-apcu mod_ssl hostname \
-                  php-ldap" && \
+                  php-ldap yarn" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     yum reinstall -y tzdata && \
     rpm -V $INSTALL_PKGS && \

--- a/8.0/root/usr/libexec/container-setup
+++ b/8.0/root/usr/libexec/container-setup
@@ -26,7 +26,7 @@ else
   rm -f /opt/app-root/etc/scl_enable
 fi
 
-if head "/etc/redhat-release" | grep -q -e "^Red Hat Enterprise Linux release 8" -e "Fedora"; then
+if head "/etc/redhat-release" | grep -q -e "^Red Hat Enterprise Linux release 8" -e "Fedora" -e "CentOS"; then
     /usr/libexec/httpd-ssl-gencerts
 fi
 

--- a/8.0/s2i/bin/assemble
+++ b/8.0/s2i/bin/assemble
@@ -58,6 +58,18 @@ if [ -f composer.json ]; then
   fi
 fi
 
+# install yarn modules
+if [ -f yarn.lock ]; then
+  echo "Found 'yarn.lock', installing dependencies using yarn... "
+
+  yarn config set network-timeout 300000
+  yarn install --pure-lockfile
+  yarn run buildall
+  yarn cache clean
+
+fi
+
+
 # post-assemble files
 process_extending_files ./php-post-assemble/ ${PHP_CONTAINER_SCRIPTS_PATH}/post-assemble/
 


### PR DESCRIPTION
hello,

for a php project using also nodejs modules https://github.com/elabftw/elabftw  i needed to have `yarn` also available on the builder image.

on this PR i'm adding the yarn installation and the build steps on `assemble` script if there's a `yarn.lock` file present on the project.

Also, for this particular project,  extra php modules were needed.

Particularly `php-pecl-imagick-im6`  has a bunch of secondary dependencies, including `graphviz` which is  available on  rhel8/centos8 appstream repos, but not in the streamlined repos of the `ubi8` images.

So I'm adding also a recipe for building a centos8 based s2i builder image, including some extra php modules.

Differences are minimal as both are rhel8 compatible, but we benefit on this of having the full stuff on upstream centos8 repos.

on the centos8 i add also the possibility to choose the nodejs version by enabling the targeted appstream module.

